### PR TITLE
bump dependency module versions so we can bump stdlib >5

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,9 +2,9 @@ fixtures:
   repositories:
     stdlib:
       repo: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-      ref: "4.25.1"
+      ref: "v6.4.0"
     apt:
       repo: "https://github.com/puppetlabs/puppetlabs-apt.git"
-      ref: "4.5.0"
+      ref: "v7.5.0"
   symlinks:
     aptly: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.0.0 <5.0.0"
+      "version_requirement": ">=4.25.1 <7.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=4.0.0 <5.0.0"
+      "version_requirement": ">=4.0.0 <8.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/spec_helper_system.rb
+++ b/spec/spec_helper_system.rb
@@ -13,7 +13,7 @@ RSpec.configure do |c|
   c.before :suite do
     puppet_install
     puppet_module_install(source: proj_root, module_name: 'aptly')
-    shell('puppet module install puppetlabs-stdlib')
-    shell('puppet module install puppetlabs-apt --version 2.2.0')
+    shell('puppet module install puppetlabs-stdlib --version 6.4.0')
+    shell('puppet module install puppetlabs-apt --version 7.5.0')
   end
 end


### PR DESCRIPTION
## What this is
In my continued effort to get stdlib >5 and get our librarian setup healthy again, I'm dusting off this fork, for the same reason we had it before :(

## Impact
since this is only a dependency version update no server configuration changes should occur

## Puppet output
### noop runs on each node_type in each environment
#### integration
```diff
Finished on bigpay-lb-2bpq.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 16.13 seconds
Finished on alertmanager-13vb.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 16.19 seconds
Finished on db-shared-1-read-9da74824.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 22.88 seconds
Finished on store-resque-3ae7d369.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 51.33 seconds
Finished on db-store-3-master-83a9de12.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: /Stage[main]/Bigcommerce_database_server::Create_orchestrator_user/Mysql_grant[orchestrator@%/*.*]/privileges: current_value ["FILE", "PROCESS", "RELOAD", "REPLICATION SLAVE", "SELECT", "SUPER"], should be FILE PROCESS RELOAD REPLICATION SLAVE SELECT SERVICE_CONNECTION_ADMIN SUPER (noop)
    Notice: Class[Bigcommerce_database_server::Create_orchestrator_user]: Would have triggered 'refresh' from 1 events
    Notice: Stage[main]: Would have triggered 'refresh' from 1 events
    Notice: Applied catalog in 66.23 seconds
Finished on consul-3fzj.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 18.78 seconds
Finished on graphite-api-f69a7a23.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 14.57 seconds
Finished on deploy-7f5095ff.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 30.01 seconds
Finished on graphite-relay-3e9a65a9.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 15.20 seconds
Finished on graphite-statsite-4bc74e9e.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 15.07 seconds
Finished on graphite-storage-430a853e.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 21.57 seconds
  STDERR:
    Warning: Facter: gce fact timed out or errored. retrying again after attempt 1
Finished on k2-app-17cf7cca.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 22.52 seconds
Finished on logs-indexer-83jz.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 28.09 seconds
Finished on mail-forwarder-jg17.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 16.50 seconds
Finished on mule-app-9jpz.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 14.11 seconds
Finished on store-lb-h1px.node.int-australia-southeast1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 80.79 seconds
Finished on nagios-1-98ca668d.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: /Stage[main]/Cis::Section_4/Package[apache2]/ensure: current_value 2.4.38-3+deb10u3, should be absent (noop)
    Notice: Class[Cis::Section_4]: Would have triggered 'refresh' from 1 events
    Notice: Stage[main]: Would have triggered 'refresh' from 1 events
    Notice: Applied catalog in 20.09 seconds
  STDERR:
    Warning: Creating htpasswd via Puppet.newtype is deprecated and will be removed in a future release. Use Puppet::Type.newtype instead.
       (at /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb:227:in `newtype')
Finished on nat-gw-cluster-33ddea14.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 15.41 seconds
Finished on nomad-client-payments-620744ea.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 21.11 seconds
Finished on nomad-server-5373d6ad.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 19.82 seconds
Finished on nomad-cache-64af6f97.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 27.67 seconds
Finished on orchestrator-15e89351.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 19.10 seconds
Finished on proxysql-shared-9h28.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 14.86 seconds
Finished on dns-ns-832393a9.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 25.26 seconds
Finished on prometheus-read-06141854.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 24.34 seconds
Finished on prometheus-b6ca240b.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 30.80 seconds
Finished on logs-filter-fs39.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 215.54 seconds
Finished on redis-sentinel-37895dfa.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 17.14 seconds
Finished on redis-vol-billing-poc-3d853d67.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 16.14 seconds
Finished on shared-lb-lb3s.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 17.50 seconds
Finished on es-store-master-ed6ad405.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 21.64 seconds
Finished on es-store-v7-master-31969228.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 20.50 seconds
Finished on teleport-auth-8g9p.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 11.97 seconds
Finished on vault-3kmg.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 13.87 seconds
Finished on rabbitmq-store-2df78fe8.node.int-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Info: Calling prefetch: k2-shovel@webhooks
    Notice: Applied catalog in 134.27 seconds
```

#### staging
```diff
Finished on alertmanager-dsz5.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 15.10 seconds
Finished on consul-r2c9.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 18.05 seconds
Finished on db-auth-1-master-16763808.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 23.29 seconds
Finished on db-store-2-master-42c1e073.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: /Stage[main]/Wazuh::Agent/Exec[agent-auth-linux]/returns: current_value notrun, should be 0 (noop)
    Notice: /Stage[main]/Wazuh::Agent/Service[wazuh-agent]/ensure: current_value stopped, should be running (noop)
    Info: /Stage[main]/Wazuh::Agent/Service[wazuh-agent]: Unscheduling refresh on Service[wazuh-agent]
    Notice: Class[Wazuh::Agent]: Would have triggered 'refresh' from 2 events
    Notice: Stage[main]: Would have triggered 'refresh' from 1 events
    Notice: Applied catalog in 29.69 seconds
Finished on store-resque-30a637c1.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 39.58 seconds
Finished on empty-soe-mike-ec54fb39.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 11.07 seconds
Finished on deploy-6c500e84.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 18.69 seconds
Finished on graphite-api-d916844a.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 12.15 seconds
Finished on graphite-relay-d6dc6883.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 20.79 seconds
Finished on graphite-statsite-f800163b.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 16.50 seconds
Finished on k2-app-a44fd749.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 22.04 seconds
Finished on graphite-storage-eb9b1ee0.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 23.50 seconds
Finished on store-lb-nx14.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 29.17 seconds
Finished on logs-indexer-r4zc.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 32.95 seconds
Finished on mail-forwarder-10c4.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 18.86 seconds
  STDERR:
    Warning: Facter: gce fact timed out or errored. retrying again after attempt 1
Finished on nagios-1-d7b8797c.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: /Stage[main]/Cis::Section_4/Package[apache2]/ensure: current_value 2.4.38-3+deb10u3, should be absent (noop)
    Notice: Class[Cis::Section_4]: Would have triggered 'refresh' from 1 events
    Notice: Stage[main]: Would have triggered 'refresh' from 1 events
    Notice: Applied catalog in 17.58 seconds
  STDERR:
    Warning: Creating htpasswd via Puppet.newtype is deprecated and will be removed in a future release. Use Puppet::Type.newtype instead.
       (at /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb:227:in `newtype')
Finished on mule-app-nsfz.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 22.16 seconds
Finished on nat-gw-payments-603db391.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 16.08 seconds
Finished on nomad-server-77c1bf2e.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 13.19 seconds
Finished on nomad-cache-f5ec39c5.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 23.61 seconds
Finished on nomad-client-17696839.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 25.97 seconds
Finished on orchestrator-378f0fc0.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: /Stage[main]/Wazuh::Agent/Concat[ossec.conf]/File[/var/ossec/etc/ossec.conf]/ensure: current_value absent, should be file (noop)
    Notice: ossec.conf: Would have triggered 'refresh' from 1 events
    Notice: Concat[ossec.conf]: Would have triggered 'refresh' from 2 events
    Info: Concat[ossec.conf]: Scheduling refresh of Service[wazuh-agent]
    Notice: /Stage[main]/Wazuh::Agent/Exec[agent-auth-linux]/returns: current_value notrun, should be 0 (noop)
    Notice: /Stage[main]/Wazuh::Agent/Service[wazuh-agent]/ensure: current_value stopped, should be running (noop)
    Info: /Stage[main]/Wazuh::Agent/Service[wazuh-agent]: Unscheduling refresh on Service[wazuh-agent]
    Notice: Class[Wazuh::Agent]: Would have triggered 'refresh' from 3 events
    Notice: Stage[main]: Would have triggered 'refresh' from 1 events
    Notice: Applied catalog in 18.92 seconds
Finished on dns-ns-e1a20d24.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 31.49 seconds
  STDERR:
    Error: Facter: GCE metadata request failed: Timeout was reached
Finished on prometheus-261a9234.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 26.62 seconds
Finished on prometheus-read-a863fb36.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 21.27 seconds
Finished on proxysql-store-h6x0.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 15.77 seconds
Finished on redis-perm-bigpay-0a96c424.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 16.73 seconds
Finished on redis-sentinel-1f411b6f.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 15.86 seconds
  STDERR:
    Error: Facter: GCE metadata request failed: Timeout was reached
Finished on rabbitmq-k2-b3acceec.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 42.45 seconds
Finished on redis-vol-theme-registry-bc3504d1.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 21.02 seconds
  STDERR:
    Warning: Facter: gce fact timed out or errored. retrying again after attempt 1
Finished on shared-lb-55xc.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 16.63 seconds
Finished on smtp-relay-d9ec69d1.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 15.68 seconds
  STDERR:
    Warning: /opt/puppetlabs/puppet/cache/lib/puppet/type/network_config.rb:6: ipaddress gem was not found
Finished on es-store-data-group-2-a2f3ebcb.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 17.50 seconds
Finished on teleport-proxy-v54m.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 13.80 seconds
Finished on vault-3psn.node.stg-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 14.01 seconds
Finished on logs-filter-m5cr.node.stg-us-central1.consul:
  STDOUT:
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 257.47 seconds
```

#### production
```diff
Finished on apt-mirror-eb5f4338.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 19.46 seconds
  STDERR:
    Warning: Creating htpasswd via Puppet.newtype is deprecated and will be removed in a future release. Use Puppet::Type.newtype instead.
       (at /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb:227:in `newtype')
Finished on alertmanager-6ppp.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 15.28 seconds
Finished on db-store-14-read-55cf2964.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 21.81 seconds
Finished on db-auth-1-master-97214a1d.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 18.19 seconds
  STDERR:
    Error: Facter: GCE metadata request failed: Timeout was reached
Finished on store-resque-5b08f154.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 36.19 seconds
Finished on bigpay-lb-d7tl.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 15.57 seconds
Finished on consul-cb861ccd.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 17.92 seconds
Finished on es-logging-master-885290c7.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 21.15 seconds
Finished on deploy-4eabd50f.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 20.70 seconds
Finished on es-logging7-kibana-dbcm.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 14.40 seconds
Finished on git-app-28e4b3ad.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 21.28 seconds
Finished on grafana-578e602c.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 19.43 seconds
  STDERR:
    Warning: Creating htpasswd via Puppet.newtype is deprecated and will be removed in a future release. Use Puppet::Type.newtype instead.
       (at /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb:227:in `newtype')
Finished on graphite-api-5f9e4591.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 13.48 seconds
Finished on graphite-relay-0f998b5f.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 27.32 seconds
Finished on graphite-statsite-cb98f686.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 35.44 seconds
Finished on k2-app-6e89d8dd.node.prd-us-central1.consul:
  STDOUT:
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 17.24 seconds
Finished on graphite-storage-d7e38db9.node.prd-us-central1.consul:
  STDOUT:
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 15.63 seconds
Finished on store-lb-kln6.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 31.30 seconds
Finished on mail-forwarder-9w7h.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 24.71 seconds
  STDERR:
    Error: Facter: GCE metadata request failed: Timeout was reached
Finished on logs-indexer-lrdz.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 37.61 seconds
Failed on nexpose-scanner-b5c7f3b2.node.prd-us-central1.consul:
  Failed to connect to nexpose-scanner-b5c7f3b2.node.prd-us-central1.consul: getaddrinfo: Name or service not known
Finished on mule-app-x7sf.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 18.36 seconds
Finished on nagios-1-4543f23f.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: /Stage[main]/Cis::Section_4/Package[apache2]/ensure: current_value 2.4.38-3+deb10u3, should be absent (noop)
    Notice: Class[Cis::Section_4]: Would have triggered 'refresh' from 1 events
    Notice: Stage[main]: Would have triggered 'refresh' from 1 events
    Notice: Applied catalog in 23.02 seconds
  STDERR:
    Warning: Creating htpasswd via Puppet.newtype is deprecated and will be removed in a future release. Use Puppet::Type.newtype instead.
       (at /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb:227:in `newtype')
Finished on nexpose-web-7690df7b.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 11.34 seconds
  STDERR:
    Error: Facter: GCE metadata request failed: Timeout was reached
Finished on nat-gw-admin-4f15b338.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 18.50 seconds
Finished on nomad-cache-8908aedb.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 22.68 seconds
Finished on logs-filter-nr2l.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 134.22 seconds
Finished on nomad-server-198712d8.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 14.11 seconds
Finished on nomad-client-504ec8fe.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 39.49 seconds
Finished on orchestrator-e0fc19b6.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 25.77 seconds
Finished on puppet-ca-8c6df037.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
  STDERR:
    Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Class[Eyaml]: has no parameter named 'manage_keys' at /opt/puppet_envs/module_bumps_continued/modules/bigcommerce_puppet/manifests/puppetmaster.pp:52:3 on node puppet-ca-8c6df037.c.bigcommerce-production.internal
    Warning: Not using cache on failed catalog
    Error: Could not retrieve catalog; skipping run
Finished on prometheus-bea4d4e7.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 13.87 seconds
Finished on puppet-master-66457d94.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
  STDERR:
    Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Class[Eyaml]: has no parameter named 'manage_keys' at /opt/puppet_envs/module_bumps_continued/modules/bigcommerce_puppet/manifests/puppetmaster.pp:52:3 on node puppet-master-66457d94.c.bigcommerce-production.internal
    Warning: Not using cache on failed catalog
    Error: Could not retrieve catalog; skipping run
Finished on prometheus-read-9aef6058.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 12.83 seconds
Finished on dns-ns-f4a067af.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: /Stage[main]/Bigcommerce_database_server::Monitoring/Service[pt-stalk]/ensure: current_value stopped, should be running (noop)
    Info: /Stage[main]/Bigcommerce_database_server::Monitoring/Service[pt-stalk]: Unscheduling refresh on Service[pt-stalk]
    Notice: Class[Bigcommerce_database_server::Monitoring]: Would have triggered 'refresh' from 1 events
    Notice: Stage[main]: Would have triggered 'refresh' from 1 events
    Notice: Applied catalog in 23.76 seconds
Finished on puppet-db-postgres-d97a573e.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 20.20 seconds
Finished on redis-perm-google-reseller-273d7c6d.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 14.16 seconds
Finished on redis-vol-billing-poc-d6e62294.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 17.09 seconds
Finished on redis-sentinel-3ddf6ad7.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 19.84 seconds
Finished on rabbitmq-mco-master-877277cb.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Info: Calling prefetch: federation-prd-us-central1@/mcollective
    Notice: Applied catalog in 47.07 seconds
  STDERR:
    Error: Facter: GCE metadata request failed: Timeout was reached
Finished on rundeck-cb42e4f2.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 16.32 seconds
Finished on shared-lb-admin-cm84.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 17.63 seconds
Finished on smtp-relay-45d52049.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 16.66 seconds
  STDERR:
    Warning: /opt/puppetlabs/puppet/cache/lib/puppet/type/network_config.rb:6: ipaddress gem was not found
Finished on es-store-data-group-2-71039a5b.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 16.20 seconds
  STDERR:
    Error: Facter: GCE metadata request failed: Timeout was reached
Finished on vault-6zqg.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 15.63 seconds
Finished on syslog-92f4fc0b.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: /Stage[main]/Bigcommerce_soe::Packages/Package[apt-dater-host]/ensure: current_value absent, should be present (noop)
    Notice: Class[Bigcommerce_soe::Packages]: Would have triggered 'refresh' from 1 events
    Notice: Stage[main]: Would have triggered 'refresh' from 1 events
    Notice: Applied catalog in 15.68 seconds
Finished on vpn-ops-us-520f61a4.node.prd-us-central1.consul:
  STDOUT:
    >> WARNING!! Using noop mode will still publish exported resources!! Use with caution!!
    >> Running puppet agent -t --environment module_bumps_continued --noop
    Info: Using configured environment 'module_bumps_continued'
    Info: Retrieving pluginfacts
    Info: Retrieving plugin
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_default_home.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_libjvm_path.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_major_version.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_patch_level.rb]/ensure: removed
    Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/java_version.rb]/ensure: removed
    Info: Loading facts
    Info: Applying configuration version '08af774 - Wed Sep 23 16:53:57 2020 -0700'
    Notice: Applied catalog in 20.75 seconds
```

## Proof of life
Life is nothing changes, nothing breaks.