### PR TITLE
Allow mirror key to be an array

### DIFF
--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -55,7 +55,7 @@
 #   Default: []
 define aptly::mirror (
   String $location,
-  Variant[String, Hash] $key = {},
+  Variant[String, Hash, Array[String]] $key = {},
   String $keyring            = '/etc/apt/trusted.gpg',
   String $filter             = '',
   String $release            = $::lsbdistcodename,


### PR DESCRIPTION
Does what the title says since the implementation allows the key to be an array https://github.com/bigcommerce/puppet-aptly/blob/c44c63da2b93b2285aad9a67ca262406f992c213/manifests/mirror.pp#L125-L126  . 