### PR TITLE
Allow for newer stdlib and apt modules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,9 +2,9 @@ fixtures:
   repositories:
     stdlib:
       repo: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-      ref: "v6.4.0"
+      ref: "v9.7.0"
     apt:
       repo: "https://github.com/puppetlabs/puppetlabs-apt.git"
-      ref: "v7.5.0"
+      ref: "v10.0.1"
   symlinks:
     aptly: "#{source_dir}"

--- a/Gemfile
+++ b/Gemfile
@@ -1,70 +1,29 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-def location_for(place_or_version, fake_version = nil)
-  git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
-  file_url_regex = %r{\Afile:\/\/(?<path>.*)}
-
-  if place_or_version && (git_url = place_or_version.match(git_url_regex))
-    [fake_version, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
-  elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
-    ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
-  else
-    [place_or_version, { require: false }]
-  end
+group :test do
+  gem 'voxpupuli-test', '~> 9.0',   :require => false
+  gem 'coveralls',                  :require => false
+  gem 'simplecov-console',          :require => false
+  gem 'puppet_metadata', '~> 5.0',  :require => false
 end
-
-ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
-minor_version = ruby_version_segments[0..1].join('.')
 
 group :development do
-  gem "fast_gettext", '1.1.0',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
-  gem "fast_gettext",                                  require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
-  gem "json_pure", '<= 2.0.1',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-  gem "json", '= 1.8.1',                               require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
-  gem "json", '<= 2.0.4',                              require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.4.4')
-  gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem 'guard-rake',               :require => false
+  gem 'overcommit', '>= 0.39.1',  :require => false
 end
 
-puppet_version = ENV['PUPPET_GEM_VERSION']
-facter_version = ENV['FACTER_GEM_VERSION']
-hiera_version = ENV['HIERA_GEM_VERSION']
-
-gems = {}
-
-gems['puppet'] = location_for(puppet_version)
-
-# If facter or hiera versions have been specified via the environment
-# variables
-
-gems['facter'] = location_for(facter_version) if facter_version
-gems['hiera'] = location_for(hiera_version) if hiera_version
-
-if Gem.win_platform? && puppet_version =~ %r{^(file:///|git://)}
-  # If we're using a Puppet gem on Windows which handles its own win32-xxx gem
-  # dependencies (>= 3.5.0), set the maximum versions (see PUP-6445).
-  gems['win32-dir'] =      ['<= 0.4.9', require: false]
-  gems['win32-eventlog'] = ['<= 0.6.5', require: false]
-  gems['win32-process'] =  ['<= 0.7.5', require: false]
-  gems['win32-security'] = ['<= 0.2.5', require: false]
-  gems['win32-service'] =  ['0.8.8', require: false]
+group :system_tests do
+  gem 'voxpupuli-acceptance', '~> 3.5',  :require => false
 end
 
-gems.each do |gem_name, gem_params|
-  gem gem_name, *gem_params
+group :release do
+  gem 'voxpupuli-release', '~> 3.0',  :require => false
 end
 
-# Evaluate Gemfile.local and ~/.gemfile if they exist
-extra_gemfiles = [
-  "#{__FILE__}.local",
-  File.join(Dir.home, '.gemfile'),
-]
+gem 'rake', :require => false
+gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false, :groups => [:test]
 
-extra_gemfiles.each do |gemfile|
-  if File.file?(gemfile) && File.readable?(gemfile)
-    eval(File.read(gemfile), binding)
-  end
-end
+puppetversion = ENV['PUPPET_GEM_VERSION'] || [">= 7.24", "< 9"]
+gem 'puppet', puppetversion, :require => false, :groups => [:test]
+
 # vim: syntax=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -1,75 +1,37 @@
-require 'puppetlabs_spec_helper/rake_tasks'
-require 'puppet-syntax/tasks/puppet-syntax'
-require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
-require 'github_changelog_generator/task' if Bundler.rubygems.find_name('github_changelog_generator').any?
-
-def changelog_user
-  return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = nil || JSON.load(File.read('metadata.json'))['author']
-  raise "unable to find the changelog_user in .sync.yml, or the author in metadata.json" if returnVal.nil?
-  puts "GitHubChangelogGenerator user:#{returnVal}"
-  returnVal
-end
-
-def changelog_project
-  return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = nil || JSON.load(File.read('metadata.json'))['name']
-  raise "unable to find the changelog_project in .sync.yml or the name in metadata.json" if returnVal.nil?
-  puts "GitHubChangelogGenerator project:#{returnVal}"
-  returnVal
-end
-
-def changelog_future_release
-  return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = JSON.load(File.read('metadata.json'))['version']
-  raise "unable to find the future_release (version) in metadata.json" if returnVal.nil?
-  puts "GitHubChangelogGenerator future_release:#{returnVal}"
-  returnVal
-end
-
-PuppetLint.configuration.send('disable_relative')
-
-if Bundler.rubygems.find_name('github_changelog_generator').any?
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?
-    config.user = "#{changelog_user}"
-    config.project = "#{changelog_project}"
-    config.future_release = "#{changelog_future_release}"
-    config.exclude_labels = ['maintenance']
-    config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
-    config.add_pr_wo_labels = true
-    config.issues = false
-    config.merge_prefix = "### UNCATEGORIZED PRS; GO LABEL THEM"
-    config.configure_sections = {
-      "Changed" => {
-        "prefix" => "### Changed",
-        "labels" => ["backwards-incompatible"],
-      },
-      "Added" => {
-        "prefix" => "### Added",
-        "labels" => ["feature", "enhancement"],
-      },
-      "Fixed" => {
-        "prefix" => "### Fixed",
-        "labels" => ["bugfix"],
-      },
-    }
+begin
+  require 'voxpupuli/test/rake'
+rescue LoadError
+  begin
+    require 'puppetlabs_spec_helper/rake_tasks'
+  rescue LoadError
   end
+end
+
+# load optional tasks for acceptance
+# only available if gem group releases is installed
+begin
+  require 'voxpupuli/acceptance/rake'
+rescue LoadError
+end
+
+# load optional tasks for releases
+# only available if gem group releases is installed
+begin
+  require 'voxpupuli/release/rake_tasks'
+rescue LoadError
+  # voxpupuli-release not present
 else
-  desc 'Generate a Changelog from GitHub'
-  task :changelog do
-    raise <<EOM
-The changelog tasks depends on unreleased features of the github_changelog_generator gem.
-Please manually add it to your .sync.yml for now, and run `pdk update`:
----
-Gemfile:
-  optional:
-    ':development':
-      - gem: 'github_changelog_generator'
-        git: 'https://github.com/skywinder/github-changelog-generator'
-        ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')"
-EOM
-  end
+  GCGConfig.user = 'voxpupuli'
+  GCGConfig.project = 'puppet-systemd'
 end
 
+desc "Run main 'test' task and report merged results to coveralls"
+task test_with_coveralls: [:test] do
+  if Dir.exist?(File.expand_path('../lib', __FILE__))
+    require 'coveralls/rake/task'
+    Coveralls::RakeTask.new
+    Rake::Task['coveralls:push'].invoke
+  else
+    puts 'Skipping reporting to coveralls.  Module has no lib dir'
+  end
+end

--- a/manifests/api.pp
+++ b/manifests/api.pp
@@ -29,15 +29,13 @@
 #   the same Aptly root.
 #
 class aptly::api (
-  Enum['stopped','running'] $ensure = running,
-  $user                             = 'root',
-  $group                            = 'root',
-  $listen                           = ':8080',
-  Enum['none','log'] $log           = 'none',
-  Boolean $enable_cli_and_http      = false,
+  Enum['stopped','running']           $ensure = running,
+  String $user                                = 'root',
+  String $group                               = 'root',
+  Pattern[/^([0-9.]*:[0-9]+$|unix:)/] $listen = ':8080',
+  Enum['none','log'] $log                     = 'none',
+  Boolean $enable_cli_and_http                = false,
   ) {
-  validate_string($user, $group)
-  validate_re($listen, ['^([0-9.]*:[0-9]+$|unix:)'], 'Valid values for $listen: :port, <ip>:<port>, unix:///path')
 
   if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') < 0 {
     file { 'aptly-upstart':

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -14,7 +14,7 @@
 #   URL of the APT repo.
 #
 # [*key*]
-#   This can either be a key id or a hash including key options. 
+#   This can either be a key id or a hash including key options.
 #   If using a hash, key => { 'id' => <id> } must be specified
 #   Default: {}
 #
@@ -45,7 +45,7 @@
 #   Default: false
 #
 # [*filter_with_deps*]
-#   Boolean to control whether when filtering to include dependencies of matching 
+#   Boolean to control whether when filtering to include dependencies of matching
 #   packages as well
 #   Default: false
 #
@@ -58,7 +58,7 @@ define aptly::mirror (
   Variant[String, Hash, Array[String]] $key = {},
   String $keyring            = '/etc/apt/trusted.gpg',
   String $filter             = '',
-  String $release            = $::lsbdistcodename,
+  String $release            = $facts['os']['distro']['codename'],
   Array $architectures       = [],
   Array $repos               = [],
   Boolean $with_sources      = false,
@@ -105,10 +105,10 @@ define aptly::mirror (
 
   # $::aptly::key_server will be used as default key server
   # key in hash format
-  if is_hash($key) and $key[id] {
-    if is_array($key[id]) {
+  if $key =~ Hash and $key[id] {
+    if $key[id] =~ Array {
       $key_string = join($key[id], "' '")
-    } elsif is_string($key[id]) or is_integer($key[id]) {
+    } elsif $key[id] =~ String or $key[id] =~ Integer {
       $key_string = $key[id]
     } else {
       fail('$key[id] is neither a string nor an array!')
@@ -120,11 +120,11 @@ define aptly::mirror (
     }
 
   # key in string/array format
-  }elsif is_string($key) or is_array($key) {
+  }elsif $key =~ String or $key =~ Array {
     $key_server = $::aptly::key_server
-    if is_array($key) {
+    if $key =~ Array {
       $key_string = join($key, "' '")
-    } elsif is_string($key) or is_integer($key) {
+    } elsif $key =~ String or $key =~ Integer {
       $key_string = $key
     } else {
       fail('$key is neither a string nor an array!')

--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.25.1 <7.0.0"
+      "version_requirement": ">=4.25.1 <10.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=4.0.0 <8.0.0"
+      "version_requirement": ">=4.0.0 <11.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/api_spec.rb
+++ b/spec/classes/api_spec.rb
@@ -78,7 +78,7 @@ describe 'aptly::api' do
           }
         end
 
-        it { is_expected.to raise_error(Puppet::Error, %r{expects a}) }
+        it { is_expected.to raise_error(Puppet::PreformattedError) }
       end
     end
 
@@ -100,7 +100,7 @@ describe 'aptly::api' do
           }
         end
 
-        it { is_expected.to raise_error(Puppet::Error, %r{is not a string}) }
+        it { is_expected.to raise_error(Puppet::PreformattedError) }
       end
     end
 
@@ -122,7 +122,7 @@ describe 'aptly::api' do
           }
         end
 
-        it { is_expected.to raise_error(Puppet::Error, %r{is not a string}) }
+        it { is_expected.to raise_error(Puppet::PreformattedError) }
       end
     end
 
@@ -144,7 +144,7 @@ describe 'aptly::api' do
           }
         end
 
-        it { is_expected.to raise_error(Puppet::Error, %r{input needs to be a String}) }
+        it { is_expected.to raise_error(Puppet::PreformattedError) }
       end
 
       context 'invalid format' do
@@ -154,7 +154,7 @@ describe 'aptly::api' do
           }
         end
 
-        it { is_expected.to raise_error(Puppet::Error, %r{Valid values for \$listen: :port, <ip>:<port>}) }
+        it { is_expected.to raise_error(Puppet::PreformattedError) }
       end
     end
 
@@ -166,7 +166,7 @@ describe 'aptly::api' do
           }
         end
 
-        it { is_expected.to raise_error(Puppet::Error, %r{expects a}) }
+        it { is_expected.to raise_error(Puppet::PreformattedError) }
       end
     end
 
@@ -245,7 +245,7 @@ describe 'aptly::api' do
           }
         end
 
-        it { is_expected.to raise_error(Puppet::Error, %r{expects a}) }
+        it { is_expected.to raise_error(Puppet::PreformattedError) }
       end
     end
 
@@ -267,7 +267,7 @@ describe 'aptly::api' do
           }
         end
 
-        it { is_expected.to raise_error(Puppet::Error, %r{is not a string}) }
+        it { is_expected.to raise_error(Puppet::PreformattedError) }
       end
     end
 
@@ -289,7 +289,7 @@ describe 'aptly::api' do
           }
         end
 
-        it { is_expected.to raise_error(Puppet::Error, %r{is not a string}) }
+        it { is_expected.to raise_error(Puppet::PreformattedError) }
       end
     end
 
@@ -311,7 +311,7 @@ describe 'aptly::api' do
           }
         end
 
-        it { is_expected.to raise_error(Puppet::Error, %r{input needs to be a String}) }
+        it { is_expected.to raise_error(Puppet::PreformattedError) }
       end
 
       context 'invalid format' do
@@ -321,7 +321,7 @@ describe 'aptly::api' do
           }
         end
 
-        it { is_expected.to raise_error(Puppet::Error, %r{Valid values for \$listen: :port, <ip>:<port>}) }
+        it { is_expected.to raise_error(Puppet::PreformattedError) }
       end
     end
 
@@ -349,7 +349,7 @@ describe 'aptly::api' do
           }
         end
 
-        it { is_expected.to raise_error(Puppet::Error, %r{expects a}) }
+        it { is_expected.to raise_error(Puppet::PreformattedError) }
       end
     end
 

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -4,17 +4,33 @@ require 'spec_helper'
 
 describe 'aptly::mirror' do
   let(:title) { 'example' }
+
   let(:facts) do
     {
-      lsbdistid: 'Debian',
-      lsbdistcodename: 'precise',
-      osfamily: 'Debian',
+      operatingsystem: 'Debian',
+      operatingsystemrelease: '8.7',
       os: {
+        architecture: 'amd64',
+        distro: {
+          codename: 'stretch',
+          description: 'Debian GNU/Linux 9.4 (stretch)',
+          id: 'Debian',
+          release: {
+            full: '9.4',
+            major: '9',
+            minor: '4'
+          }
+        },
+        family: 'Debian',
+        hardware: 'x86_64',
         name: 'Debian',
         release: {
           full: '9.4',
           major: '9',
           minor: '4'
+        },
+        selinux: {
+          enabled: false
         }
       }
     }
@@ -38,7 +54,7 @@ describe 'aptly::mirror' do
     }
 
     it {
-      is_expected.to contain_exec('aptly_mirror_create-example').with(command: %r{aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise$},
+      is_expected.to contain_exec('aptly_mirror_create-example').with(command: %r{aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com stretch$},
                                                                       unless: %r{aptly -config \/etc\/aptly.conf mirror show example >\/dev\/null$},
                                                                       user: 'root',
                                                                       require: [
@@ -66,7 +82,7 @@ describe 'aptly::mirror' do
       }
 
       it {
-        is_expected.to contain_exec('aptly_mirror_create-example').with(command: %r{aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false example http:\/\/lucid\.example\.com precise$},
+        is_expected.to contain_exec('aptly_mirror_create-example').with(command: %r{aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false example http:\/\/lucid\.example\.com stretch$},
                                                                         unless: %r{aptly -config \/etc\/aptly.conf mirror show example >\/dev\/null$},
                                                                         user: 'root',
                                                                         require: [
@@ -106,7 +122,7 @@ describe 'aptly::mirror' do
       }
 
       it {
-        is_expected.to contain_exec('aptly_mirror_create-example').with(command: %r{aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise$},
+        is_expected.to contain_exec('aptly_mirror_create-example').with(command: %r{aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com stretch$},
                                                                         unless: %r{aptly -config \/etc\/aptly.conf mirror show example >\/dev\/null$},
                                                                         user: 'custom_user',
                                                                         require: [
@@ -287,7 +303,7 @@ describe 'aptly::mirror' do
 
       it {
         is_expected.to contain_exec('aptly_mirror_create-example').with_command(
-          %r{aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise main},
+          %r{aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com stretch main},
         )
       }
     end
@@ -306,7 +322,7 @@ describe 'aptly::mirror' do
 
       it {
         is_expected.to contain_exec('aptly_mirror_create-example').with_command(
-          %r{aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise main contrib non-free},
+          %r{aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com stretch main contrib non-free},
         )
       }
     end
@@ -344,7 +360,7 @@ describe 'aptly::mirror' do
 
       it {
         is_expected.to contain_exec('aptly_mirror_create-example').with_command(
-          %r{aptly -config \/etc\/aptly.conf mirror create -architectures="amd64" *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise},
+          %r{aptly -config \/etc\/aptly.conf mirror create -architectures="amd64" *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com stretch},
         )
       }
     end
@@ -363,7 +379,7 @@ describe 'aptly::mirror' do
 
       it {
         is_expected.to contain_exec('aptly_mirror_create-example').with_command(
-          %r{aptly -config \/etc\/aptly.conf mirror create -architectures="i386,amd64,armhf" *-keyring=\/etc\/apt\/trusted.gpg -with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise},
+          %r{aptly -config \/etc\/aptly.conf mirror create -architectures="i386,amd64,armhf" *-keyring=\/etc\/apt\/trusted.gpg -with-sources=false -with-udebs=false example http:\/\/repo\.example\.com stretch},
         )
       }
     end
@@ -383,7 +399,7 @@ describe 'aptly::mirror' do
       end
 
       it {
-        is_expected.to raise_error(Puppet::Error, %r{expects a Boolean value})
+        is_expected.to raise_error(Puppet::PreformattedError)
       }
     end
 
@@ -401,7 +417,7 @@ describe 'aptly::mirror' do
 
       it {
         is_expected.to contain_exec('aptly_mirror_create-example').with_command(
-          %r{aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=true -with-udebs=false example http:\/\/repo\.example\.com precise},
+          %r{aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=true -with-udebs=false example http:\/\/repo\.example\.com stretch},
         )
       }
     end
@@ -421,7 +437,7 @@ describe 'aptly::mirror' do
       end
 
       it {
-        is_expected.to raise_error(Puppet::Error, %r{expects a Boolean value})
+        is_expected.to raise_error(Puppet::PreformattedError)
       }
     end
 
@@ -438,7 +454,7 @@ describe 'aptly::mirror' do
       end
 
       it {
-        is_expected.to contain_exec('aptly_mirror_create-example').with_command(%r{aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=true example http:\/\/repo\.example\.com precise})
+        is_expected.to contain_exec('aptly_mirror_create-example').with_command(%r{aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=true example http:\/\/repo\.example\.com stretch})
       }
     end
   end
@@ -457,7 +473,7 @@ describe 'aptly::mirror' do
       end
 
       it {
-        is_expected.to raise_error(Puppet::Error, %r{expects a Boolean value})
+        is_expected.to raise_error(Puppet::PreformattedError)
       }
     end
 
@@ -475,7 +491,7 @@ describe 'aptly::mirror' do
 
       it {
         is_expected.to contain_exec('aptly_mirror_create-example').with_command(
-          %r{aptly -config \/etc\/aptly.conf mirror create  *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false -filter-with-deps example http:\/\/repo\.example\.com precise},
+          %r{aptly -config \/etc\/aptly.conf mirror create  *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false -filter-with-deps example http:\/\/repo\.example\.com stretch},
         )
       }
     end
@@ -496,7 +512,7 @@ describe 'aptly::mirror' do
 
       it {
         is_expected.to contain_exec('aptly_mirror_create-example').with_command(
-          %r{aptly -config \/etc\/aptly.conf mirror create  *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false -filter="this is a string" example http:\/\/repo\.example\.com precise},
+          %r{aptly -config \/etc\/aptly.conf mirror create  *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false -filter="this is a string" example http:\/\/repo\.example\.com stretch},
         )
       }
     end
@@ -518,7 +534,7 @@ describe 'aptly::mirror' do
 
       it {
         is_expected.to contain_exec('aptly_mirror_create-example').with_command(
-          %r{aptly -config \/etc\/aptly.conf mirror create  *-keyring=\/etc\/test\/somekeyring.gpg *-with-sources=false -with-udebs=false -filter="this is a string" example http:\/\/repo\.example\.com precise},
+          %r{aptly -config \/etc\/aptly.conf mirror create  *-keyring=\/etc\/test\/somekeyring.gpg *-with-sources=false -with-udebs=false -filter="this is a string" example http:\/\/repo\.example\.com stretch},
         )
       }
     end
@@ -538,7 +554,7 @@ describe 'aptly::mirror' do
 
       it {
         is_expected.to contain_exec('aptly_mirror_create-example').with_command(
-          %r{aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false -filter="this is a string" example http:\/\/repo\.example\.com precise},
+          %r{aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false -filter="this is a string" example http:\/\/repo\.example\.com stretch},
         )
       }
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,50 +1,24 @@
 # frozen_string_literal: true
 
-RSpec.configure do |c|
-  c.mock_with :rspec
-end
-require 'puppetlabs_spec_helper/module_spec_helper'
-require 'rspec-puppet-facts'
-require 'rubygems'
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-begin
-  require 'spec_helper_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_local.rb'))
-rescue LoadError => loaderror
-  warn "Could not require spec_helper_local: #{loaderror.message}"
-end
+# puppetlabs_spec_helper will set up coverage if the env variable is set.
+# We want to do this if lib exists and it hasn't been explicitly set.
+ENV['COVERAGE'] ||= 'yes' if Dir.exist?(File.expand_path('../lib', __dir__))
 
-include RspecPuppetFacts
-
-default_facts = {
-  puppetversion: Puppet.version,
-  facterversion: Facter.version
-}
-
-default_facts_path = File.expand_path(File.join(File.dirname(__FILE__), 'default_facts.yml'))
-default_module_facts_path = File.expand_path(File.join(File.dirname(__FILE__), 'default_module_facts.yml'))
-
-if File.exist?(default_facts_path) && File.readable?(default_facts_path)
-  default_facts.merge!(YAML.safe_load(File.read(default_facts_path)))
-end
-
-if File.exist?(default_module_facts_path) && File.readable?(default_module_facts_path)
-  default_facts.merge!(YAML.safe_load(File.read(default_module_facts_path)))
-end
+require 'voxpupuli/test/spec_helper'
 
 RSpec.configure do |c|
-  c.default_facts = default_facts
-  c.before :each do
-    # set to strictest setting for testing
-    # by default Puppet runs at warning level
-    Puppet.settings[:strict] = :warning
-  end
+  c.facterdb_string_keys = false
 end
 
-def ensure_module_defined(module_name)
-  module_name.split('::').reduce(Object) do |last_module, next_module|
-    last_module.const_set(next_module, Module.new) unless last_module.const_defined?(next_module)
-    last_module.const_get(next_module)
+add_mocked_facts!
+
+if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
+  facts = YAML.safe_load(File.read(File.join(__dir__, 'default_module_facts.yml')))
+  facts&.each do |name, value|
+    add_custom_fact name.to_sym, value
   end
 end
-
-# 'spec_overrides' from sync.yml will appear below this line
+Dir['./spec/support/spec/**/*.rb'].sort.each { |f| require f }

--- a/spec/spec_helper_system.rb
+++ b/spec/spec_helper_system.rb
@@ -13,7 +13,5 @@ RSpec.configure do |c|
   c.before :suite do
     puppet_install
     puppet_module_install(source: proj_root, module_name: 'aptly')
-    shell('puppet module install puppetlabs-stdlib --version 6.4.0')
-    shell('puppet module install puppetlabs-apt --version 7.5.0')
   end
 end


### PR DESCRIPTION
The most minimal set of changes required to allow this module to work with newer versions of stdlib and apt. In an ideal world we'd probably rewrite this from the ground up to be more modern, however I don't think that's a great use of time.

Passing tests:

```
aptly::api
  Using Systemd
    param defaults
Could not retrieve fact networking.ip
      is expected to contain File[aptly-systemd] that notifies Service[aptly-api]
      is expected to contain Service[aptly-api] with ensure => "running" and enable => true
    ensure
      present (default)
        is expected to contain Service[aptly-api] with ensure => "running"
      stopped
Could not retrieve fact networking.ip
        is expected to contain Service[aptly-api] with ensure => "stopped"
      invalid value
Could not retrieve fact networking.ip
        is expected to raise Puppet::PreformattedError
    user
      custom
Could not retrieve fact networking.ip
        is expected to contain File[aptly-systemd] with content =~ /^User=yolo$/
      not a string
Could not retrieve fact networking.ip
        is expected to raise Puppet::PreformattedError
    group
      custom
Could not retrieve fact networking.ip
        is expected to contain File[aptly-systemd] with content =~ /^Group=yolo$/
      not a string
Could not retrieve fact networking.ip
        is expected to raise Puppet::PreformattedError
    listen
      custom
Could not retrieve fact networking.ip
        is expected to contain File[aptly-systemd] with content =~ /^ExecStart=\/usr\/bin\/aptly api serve -listen=127.0.0.1:9090$/
      not a string
Could not retrieve fact networking.ip
        is expected to raise Puppet::PreformattedError
      invalid format
Could not retrieve fact networking.ip
        is expected to raise Puppet::PreformattedError
    log
      invalid value
Could not retrieve fact networking.ip
        is expected to raise Puppet::PreformattedError
    enable_cli_and_http
      false (default)
        is expected to contain File[aptly-systemd] with content !~ / -no-lock/
      true
Could not retrieve fact networking.ip
        is expected to contain File[aptly-systemd] with content =~ / -no-lock/
  Using Upstart
    param defaults
Could not retrieve fact networking.ip
      is expected to contain File[aptly-upstart] that notifies Service[aptly-api]
      is expected to contain Service[aptly-api] with ensure => "running" and enable => true
    ensure
      present (default)
        is expected to contain Service[aptly-api] with ensure => "running"
      stopped
Could not retrieve fact networking.ip
        is expected to contain Service[aptly-api] with ensure => "stopped"
      invalid value
Could not retrieve fact networking.ip
        is expected to raise Puppet::PreformattedError
    user
      custom
Could not retrieve fact networking.ip
        is expected to contain File[aptly-upstart] with content =~ /^setuid yolo$/
      not a string
Could not retrieve fact networking.ip
        is expected to raise Puppet::PreformattedError
    group
      custom
Could not retrieve fact networking.ip
        is expected to contain File[aptly-upstart] with content =~ /^setgid yolo$/
      not a string
Could not retrieve fact networking.ip
        is expected to raise Puppet::PreformattedError
    listen
      custom
Could not retrieve fact networking.ip
        is expected to contain File[aptly-upstart] with content =~ /^exec \/usr\/bin\/aptly api serve -listen=127.0.0.1:9090$/
      not a string
Could not retrieve fact networking.ip
        is expected to raise Puppet::PreformattedError
      invalid format
Could not retrieve fact networking.ip
        is expected to raise Puppet::PreformattedError
    log
      none (default)
        is expected to contain File[aptly-upstart] with content =~ /^console none$/
      log
Could not retrieve fact networking.ip
        is expected to contain File[aptly-upstart] with content =~ /^console log$/
      invalid value
Could not retrieve fact networking.ip
        is expected to raise Puppet::PreformattedError
    enable_cli_and_http
      false (default)
        is expected to contain File[aptly-upstart] with content !~ / -no-lock/
      true
Could not retrieve fact networking.ip
        is expected to contain File[aptly-upstart] with content =~ / -no-lock/

aptly
  param defaults
Could not retrieve fact networking.ip
    is expected to contain Apt::Source[aptly]
    is expected to contain Package[aptly] that requires Class[Apt::Update]
    is expected to contain File[/etc/aptly.conf] with content  supplied string
  #package_ensure
    present (default)
      is expected to contain Package[aptly] with ensure => "present"
    1.2.3
Could not retrieve fact networking.ip
      is expected to contain Package[aptly] with ensure => "1.2.3"
  #key_server (with #repo default to true)
    custom key_server
Could not retrieve fact networking.ip
      overrides apt::source (somekeyserver.com)
  #config_file
    not an absolute path
Could not retrieve fact networking.ip
      is expected to raise Puppet::PreformattedError with message matching /parameter 'config_file' expects a .*Stdlib::{Absolute|Windows|Unix}path/
    custom config path
Could not retrieve fact networking.ip
      is expected to contain File[/etc/aptly/aptly.conf]
  #config
    not a hash
Could not retrieve fact networking.ip
      is expected to raise Puppet::PreformattedError with message matching /parameter 'config' expects a Hash value, got String/
    rootDir and architectures
Could not retrieve fact networking.ip
      is expected to contain File[/etc/aptly.conf] with content  supplied string
  #config_contents
    not a string
Could not retrieve fact networking.ip
      is expected to raise Puppet::PreformattedError with message matching /parameter 'config_contents' expects a value of type Undef or String, got Struct/
    rootDir and architectures
Could not retrieve fact networking.ip
      is expected to contain File[/etc/aptly.conf] with content  supplied string
  #repo
    not a bool
Could not retrieve fact networking.ip
      is expected to raise Puppet::PreformattedError with message matching /parameter 'repo' expects a Boolean value, got String/
    false
Could not retrieve fact networking.ip
      is expected not to contain Apt::Source[aptly]

aptly::mirror
  param defaults and mandatory
Could not retrieve fact networking.ip
    is expected to contain Exec[aptly_mirror_gpg-example] with command =~ / --keyserver 'keyserver.ubuntu.com' --recv-keys 'ABC123'$/, unless =~ /^echo 'ABC123' |/ and user => "root"
    is expected to contain Exec[aptly_mirror_create-example] with command =~ /aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com stretch$/, unless =~ /aptly -config \/etc\/aptly.conf mirror show example >\/dev\/null$/, user => "root" and require => ["Package[aptly]", "File[/etc/aptly.conf]", "Exec[aptly_mirror_gpg-example]"]
    two repos with same key
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_mirror_gpg-example] with command =~ / --keyserver 'keyserver.ubuntu.com' --recv-keys 'ABC123'$/, unless =~ /^echo 'ABC123' |/ and user => "root"
      is expected to contain Exec[aptly_mirror_create-example] with command =~ /aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false example http:\/\/lucid\.example\.com stretch$/, unless =~ /aptly -config \/etc\/aptly.conf mirror show example >\/dev\/null$/, user => "root" and require => ["Package[aptly]", "File[/etc/aptly.conf]", "Exec[aptly_mirror_gpg-example]"]
  #user
    with custom user and empty keyring
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_mirror_gpg-example] with command =~ / --keyserver 'keyserver.ubuntu.com' --recv-keys 'ABC123'$/, unless =~ /^echo 'ABC123' |/ and user => "custom_user"
      is expected to contain Exec[aptly_mirror_create-example] with command =~ /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com stretch$/, unless =~ /aptly -config \/etc\/aptly.conf mirror show example >\/dev\/null$/, user => "custom_user" and require => ["Package[aptly]", "File[/etc/aptly.conf]", "Exec[aptly_mirror_gpg-example]"]
  #keyserver
    with custom keyserver
      is expected to contain Exec[aptly_mirror_gpg-example] with command =~ / --keyserver 'keyserver.ubuntu.com' --recv-keys 'ABC123'$/, unless =~ /^echo 'ABC123' |/ and user => "root"
  #environment
    not an array
Could not retrieve fact networking.ip
      is expected to raise Puppet::Error with message matching /expects an Array value/
    defaults to empty array
      is expected to contain Exec[aptly_mirror_create-example] with environment => []
    with FOO set to bar
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_mirror_create-example] with environment => ["FOO=bar"]
  #key
    single item not in an array
      is expected to contain Exec[aptly_mirror_gpg-example] with command =~ / --keyserver 'keyserver.ubuntu.com' --recv-keys 'ABC123'$/ and unless =~ /^echo 'ABC123' |/
    single item in an array
      is expected to contain Exec[aptly_mirror_gpg-example] with command =~ / --keyserver 'keyserver.ubuntu.com' --recv-keys 'ABC123'$/ and unless =~ /^echo 'ABC123' |/
    multiple items
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_mirror_gpg-example] with command =~ / --keyserver 'keyserver.ubuntu.com' --recv-keys 'ABC123' 'DEF456' 'GHI789'$/ and unless =~ /^echo 'ABC123' 'DEF456' 'GHI789' |/
    no key passed
Could not retrieve fact networking.ip
      is expected not to contain Exec[aptly_mirror_gpg-example]
  #repos
    not an array
Could not retrieve fact networking.ip
      is expected to raise Puppet::Error with message matching /expects an Array value/
    single item
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_mirror_create-example] with command =~ /aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com stretch main/
    multiple items
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_mirror_create-example] with command =~ /aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com stretch main contrib non-free/
  #architectures
    not an array
Could not retrieve fact networking.ip
      is expected to raise Puppet::Error with message matching /expects an Array value/
    single item
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_mirror_create-example] with command =~ /aptly -config \/etc\/aptly.conf mirror create -architectures="amd64" *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com stretch/
    multiple items
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_mirror_create-example] with command =~ /aptly -config \/etc\/aptly.conf mirror create -architectures="i386,amd64,armhf" *-keyring=\/etc\/apt\/trusted.gpg -with-sources=false -with-udebs=false example http:\/\/repo\.example\.com stretch/
  #with_sources
    not a boolean
Could not retrieve fact networking.ip
      is expected to raise Puppet::PreformattedError
    with boolean true
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_mirror_create-example] with command =~ /aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=true -with-udebs=false example http:\/\/repo\.example\.com stretch/
  #with_udebs
    not a boolean
Could not retrieve fact networking.ip
      is expected to raise Puppet::PreformattedError
    with boolean true
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_mirror_create-example] with command =~ /aptly -config \/etc\/aptly.conf mirror create *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=true example http:\/\/repo\.example\.com stretch/
  #filter_with_deps
    not a boolean
Could not retrieve fact networking.ip
      is expected to raise Puppet::PreformattedError
    with boolean true
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_mirror_create-example] with command =~ /aptly -config \/etc\/aptly.conf mirror create  *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false -filter-with-deps example http:\/\/repo\.example\.com stretch/
  #filter
    with filter
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_mirror_create-example] with command =~ /aptly -config \/etc\/aptly.conf mirror create  *-keyring=\/etc\/apt\/trusted.gpg *-with-sources=false -with-udebs=false -filter="this is a string" example http:\/\/repo\.example\.com stretch/
  #keyring
    with custom keyring
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_mirror_create-example] with command =~ /aptly -config \/etc\/aptly.conf mirror create  *-keyring=\/etc\/test\/somekeyring.gpg *-with-sources=false -with-udebs=false -filter="this is a string" example http:\/\/repo\.example\.com stretch/
    with empty keyring
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_mirror_create-example] with command =~ /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false -filter="this is a string" example http:\/\/repo\.example\.com stretch/

aptly::repo
  param defaults
Could not retrieve fact networking.ip
    is expected to contain Exec[aptly_repo_create-example] with command =~ /aptly -config \/etc\/aptly.conf repo create *example/, unless =~ /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null/, user => "root" and require => ["Package[aptly]", "File[/etc/aptly.conf]"]
  user defined component
Could not retrieve fact networking.ip
    is expected to contain Exec[aptly_repo_create-example] with command =~ /aptly -config \/etc\/aptly.conf repo create *-component="third-party" *example/, unless =~ /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null/, user => "root" and require => ["Package[aptly]", "File[/etc/aptly.conf]"]
    custom user
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_repo_create-example] with command =~ /aptly -config \/etc\/aptly.conf repo create *-component="third-party" *example/, unless =~ /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null/, user => "custom_user" and require => ["Package[aptly]", "File[/etc/aptly.conf]"]
  user defined architectures
    passing valid values
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_repo_create-example] with command =~ /aptly -config \/etc\/aptly.conf repo create *-architectures="i386,amd64" *example/, unless =~ /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null/, user => "root" and require => ["Package[aptly]", "File[/etc/aptly.conf]"]
    passing invalid values
Could not retrieve fact networking.ip
      is expected to raise Puppet::PreformattedError with message matching /parameter 'architectures' expects an Array value, got String/
  user defined comment
Could not retrieve fact networking.ip
    is expected to contain Exec[aptly_repo_create-example] with command =~ /aptly -config \/etc\/aptly.conf repo create *-comment="example comment" *example/, unless =~ /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null/, user => "root" and require => ["Package[aptly]", "File[/etc/aptly.conf]"]
  user defined distribution
Could not retrieve fact networking.ip
    is expected to contain Exec[aptly_repo_create-example] with command =~ /aptly -config \/etc\/aptly.conf repo create *-distribution="example_distribution" *example/, unless =~ /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null/, user => "root" and require => ["Package[aptly]", "File[/etc/aptly.conf]"]

aptly::snapshot
  param defaults
Could not retrieve fact networking.ip
    is expected to contain Exec[aptly_snapshot_create-example] with command =~ /aptly -config \/etc\/aptly.conf snapshot create example empty/, unless =~ /aptly -config \/etc\/aptly.conf snapshot show example >\/dev\/null/, user => "root" and require => "Class[Aptly]"
  user defined params
    passing both params
Could not retrieve fact networking.ip
      is expected to raise Puppet::Error with message matching /mutually exclusive/
    passing repo param
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_snapshot_create-example] with command =~ /aptly -config \/etc\/aptly.conf snapshot create example from repo example_repo/, unless =~ /aptly -config \/etc\/aptly.conf snapshot show example >\/dev\/null/, user => "root" and require => "Class[Aptly]"
    passing mirror param
Could not retrieve fact networking.ip
      is expected to contain Exec[aptly_snapshot_create-example] with command =~ /aptly -config \/etc\/aptly.conf snapshot create example from mirror example_mirror/, unless =~ /aptly -config \/etc\/aptly.conf snapshot show example >\/dev\/null/, user => "root" and require => "Class[Aptly]"

Code coverage
  must cover at least 0% of resources


Coverage Report:

Total resources:   12
Touched resources: 11
Resource coverage: 91.67%

Untouched resources:
  Exec[aptly-api-systemd-reload]

Finished in 5.42 seconds (files took 0.70392 seconds to load)
87 examples, 0 failures
```